### PR TITLE
KON-224: Added configurable SAML username attribute

### DIFF
--- a/Security/SAMLAuthenticator.php
+++ b/Security/SAMLAuthenticator.php
@@ -90,10 +90,33 @@ class SAMLAuthenticator extends AbstractGuardAuthenticator
             ));
         }
 
-        $username = $auth->getNameId();
+        $username = $this->getUsername($auth);
         $user = $userProvider->getUser($username, $credentials);
 
         return $user;
+    }
+
+    /**
+     * Get username.
+     *
+     * @param Auth $auth
+     *
+     * @return string
+     */
+    private function getUsername(Auth $auth)
+    {
+        if (isset($this->settings['username_attribute_name'])) {
+            $attribute = $auth->getAttribute($this->settings['username_attribute_name']);
+            if (!empty($attribute)) {
+                $username = reset($attribute);
+                if (!empty($username)) {
+                    return $username;
+                }
+            }
+        }
+
+        // Fallback.
+        return $auth->getNameId();
     }
 
     public function checkCredentials($credentials, UserInterface $user)


### PR DESCRIPTION
https://jira.itkdev.dk/browse/KON-224

The folks at Kontrolgruppen want to identify case workers (users) by their AZ-identity. This change makes it possible to use a customizable SAML attribute as username (rather than the email address).

Do we want to change to username (from email) to AZ-ident or should we add additional attributes to the `User` object to store both email and AZ-ident? 