### PR TITLE
KON-286: Fixed ordering of journal entries

### DIFF
--- a/Controller/JournalEntryController.php
+++ b/Controller/JournalEntryController.php
@@ -103,7 +103,7 @@ class JournalEntryController extends BaseController
             $qb->andWhere('e.process = :process');
             $qb->setParameter('process', $process);
 
-            $qb->orderBy('e.id', $sortDirection);
+            $qb->orderBy('e.createdAt', $sortDirection);
 
             $result = $qb->getQuery()->getArrayResult();
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/KON-286

Ordering by “Newest first” or “Oldest first” should use timestamps and not rely on ids being assigned in a specific order.